### PR TITLE
Add CMakeLists to support TfheRust Boolean Attributes

### DIFF
--- a/lib/Dialect/TfheRustBool/CMakeLists.txt
+++ b/lib/Dialect/TfheRustBool/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_dialect_library(MLIRTfheRustBool
         MLIRTfheRustBoolIncGen
         MLIRTfheRustBoolOpsIncGen
         MLIRTfheRustBoolOpsTypesIncGen
+        MLIRTfheRustBoolAttributesIncGen
 
         LINK_LIBS PUBLIC
         MLIRIR

--- a/lib/Dialect/TfheRustBool/IR/CMakeLists.txt
+++ b/lib/Dialect/TfheRustBool/IR/CMakeLists.txt
@@ -12,3 +12,8 @@ set(LLVM_TARGET_DEFINITIONS TfheRustBoolTypes.td)
 mlir_tablegen(TfheRustBoolTypes.h.inc -gen-typedef-decls)
 mlir_tablegen(TfheRustBoolTypes.cpp.inc -gen-typedef-defs)
 add_public_tablegen_target(MLIRTfheRustBoolOpsTypesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TfheRustBoolAttributes.td)
+mlir_tablegen(TfheRustBoolAttributes.cpp.inc -gen-attrdef-defs -typedefs-dialect=tfhe_rust_boo)
+mlir_tablegen(TfheRustBoolAttributes.h.inc -gen-attrdef-decls -typedefs-dialect=tfhe_rust_bool)
+add_public_tablegen_target(MLIRTfheRustBoolAttributesIncGen)

--- a/lib/Dialect/TfheRustBool/IR/TfheRustBoolAttributes.td
+++ b/lib/Dialect/TfheRustBool/IR/TfheRustBoolAttributes.td
@@ -16,13 +16,20 @@ def TfheRustBoolGate_Attr : TfheRustBool_Attr<"TfheRustBoolGate", "tfhe_rust_boo
   let summary = "An Attribute containing an array of strings to store bool gates";
 
   let description = [{
-    This attributes stores a list of string identifiers for Boolean gates.
+     This attributes stores a list of string identifiers for Boolean gates.
 
-     This used in the `tfhe_rust_bool.packed_gates` operation to indicate the boolean gate that applies pairwise between elements of two ciphertext arrays. For example,
+     This used in the `tfhe_rust_bool.packed_gates` operation to indicate the boolean 
+     gate that applies pairwise between elements of two ciphertext arrays. For example,
 
-     %0 = tfhe_rust_bool.packed_gates %a, %b {gates = #tfhe_rust_bool.tfhe_rust_bool_gate<"and", "xor">} : (!tfhe_rust_bool.server_key, tensor<2x!tfhe_rust_bool.eb>, tensor<2x!tfhe_rust_bool.eb>) -> tensor<2x!tfhe_rust_bool.eb>
+     ```mlir
+     %0 = tfhe_rust_bool.packed_gates %a, %b {gates = <"and", "xor">} : 
+         (!tfhe_rust_bool.server_key, 
+          tensor<2x!tfhe_rust_bool.eb>, 
+          tensor<2x!tfhe_rust_bool.eb>) -> tensor<2x!tfhe_rust_bool.eb>
+     ```
 
-     applies an "and" gate between the first elements of %a and %b and an xor gate between the second elements.
+     applies an "and" gate to the first elements of %a and %b and an xor gate to the
+     second elements.
   }];
 
   let parameters = (ins


### PR DESCRIPTION
Add CMakeLists to support TfheRust Boolean Attributes
To fully build CMakeLists we need to merge with main which maybe done before merge of this PR to upstream.